### PR TITLE
Fix Insertion Indices

### DIFF
--- a/Changeset/Changeset.swift
+++ b/Changeset/Changeset.swift
@@ -118,11 +118,11 @@ public struct Changeset<T: CollectionType where T.Generator.Element: Equatable, 
 						del.append(deletion)
 						d[i][j] = del
 					} else if ins.count == minimumCount {
-						let insertion = Edit(.Insertion, value: t[tx], destination: i)
+						let insertion = Edit(.Insertion, value: t[tx], destination: j - 1)
 						ins.append(insertion)
 						d[i][j] = ins
 					} else {
-						let substitution = Edit(.Substitution, value: t[tx], destination: i - 1)
+						let substitution = Edit(.Substitution, value: t[tx], destination: j - 1)
 						sub.append(substitution)
 						d[i][j] = sub
 					}

--- a/Changeset/Changeset.swift
+++ b/Changeset/Changeset.swift
@@ -72,7 +72,6 @@ public struct Changeset<T: CollectionType where T.Generator.Element: Equatable, 
 		let m = s.count
 		let n = t.count
 		
-		
 		// Fill first row and column of insertions and deletions.
 		
 		var d: [[[Edit<T.Generator.Element>]]] = Array(count: m + 1, repeatedValue: Array(count: n + 1, repeatedValue: []))
@@ -93,11 +92,11 @@ public struct Changeset<T: CollectionType where T.Generator.Element: Equatable, 
 		
 		guard m > 0 && n > 0 else { return d[m][n] }
 		
-		// Fill body of matrix.
-		
 		// Indexes into the two collections.
 		var sx: T.Index
 		var tx = t.startIndex
+		
+		// Fill body of matrix.
 		
 		for j in 1...n {
 			sx = s.startIndex

--- a/ChangesetTests/ChangesetTests.swift
+++ b/ChangesetTests/ChangesetTests.swift
@@ -132,6 +132,51 @@ class ChangesetTests: XCTestCase {
 		XCTAssertEqual(changeset.edits, edits)
 	}
 	
+	func testDeLongTweet() {
+		
+		// https://twitter.com/davedelong/status/671051521371406336
+		
+		var changeset: Changeset<String.CharacterView>
+		var edits: Array<Edit<String.CharacterView.Generator.Element>>
+		
+		changeset = Changeset(source: "words".characters, target: "tsword".characters)
+		edits = [
+			Edit(.Insertion, value: "t", destination: 0),
+			Edit(.Move(origin: 4), value: "s", destination: 1),
+		]
+		XCTAssertEqual(changeset.edits, edits)
+		
+		changeset = Changeset(source: "abcdefgh".characters, target: "agbcdefh".characters)
+		edits = [
+			Edit(.Move(origin: 6), value: "g", destination: 1),
+		]
+		XCTAssertEqual(changeset.edits, edits)
+		
+		changeset = Changeset(source: "stick".characters, target: "tact".characters)
+		edits = [
+			Edit(.Deletion, value: "s", destination: 0),
+			Edit(.Substitution, value: "a", destination: 1),
+			Edit(.Substitution, value: "t", destination: 3),
+		]
+		XCTAssertEqual(changeset.edits, edits)
+		
+		changeset = Changeset(source: "12345".characters, target: "2a3".characters)
+		edits = [
+			Edit(.Deletion, value: "1", destination: 0),
+			Edit(.Insertion, value: "a", destination: 1),
+			Edit(.Deletion, value: "4", destination: 3),
+			Edit(.Deletion, value: "5", destination: 4),
+		]
+		XCTAssertEqual(changeset.edits, edits)
+		
+		changeset = Changeset(source: "dave".characters, target: "david".characters)
+		edits = [
+			Edit(.Substitution, value: "i", destination: 3),
+			Edit(.Insertion, value: "d", destination: 4),
+		]
+		XCTAssertEqual(changeset.edits, edits)
+	}
+	
 	func testEmptyStrings() {
 		
 		var changeset: Changeset<String.CharacterView>

--- a/ChangesetTests/ChangesetTests.swift
+++ b/ChangesetTests/ChangesetTests.swift
@@ -132,6 +132,30 @@ class ChangesetTests: XCTestCase {
 		XCTAssertEqual(changeset.edits, edits)
 	}
 	
+	func testComplexChange() {
+		
+		var changeset: Changeset<String.CharacterView>
+		var edits: Array<Edit<String.CharacterView.Generator.Element>>
+		
+		changeset = Changeset(source: "abcdefgh".characters, target: "bacefxhi".characters)
+		edits = [
+			Edit(.Move(origin: 1), value: "b", destination: 0),
+			Edit(.Deletion, value: "d", destination: 3),
+			Edit(.Substitution, value: "x", destination: 5),
+			Edit(.Insertion, value: "i", destination: 7),
+		]
+		XCTAssertEqual(changeset.edits, edits)
+		
+		changeset = Changeset(source: "bacefxhi".characters, target: "abcdefgh".characters)
+		edits = [
+			Edit(.Move(origin: 1), value: "a", destination: 0),
+			Edit(.Insertion, value: "d", destination: 3),
+			Edit(.Substitution, value: "g", destination: 6),
+			Edit(.Deletion, value: "i", destination: 7),
+		]
+		XCTAssertEqual(changeset.edits, edits)
+	}
+	
 	func testListing7_8() {
 		
 		// https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/ManageInsertDeleteRow/ManageInsertDeleteRow.html#//apple_ref/doc/uid/TP40007451-CH10-SW16

--- a/ChangesetTests/ChangesetTests.swift
+++ b/ChangesetTests/ChangesetTests.swift
@@ -45,21 +45,21 @@ class ChangesetTests: XCTestCase {
 		edits = [
 			Edit(.Deletion, value: "a", destination: 1),
 			Edit(.Deletion, value: "t", destination: 2),
-			Edit(.Substitution, value: "n", destination: 4),
+			Edit(.Substitution, value: "n", destination: 2),
 		]
 		XCTAssertEqual(changeset.edits, edits)
 		
 		changeset = Changeset(source: "Sunday".characters, target: "Saturday".characters)
 		edits = [
 			Edit(.Insertion, value: "a", destination: 1),
-			Edit(.Insertion, value: "t", destination: 1),
-			Edit(.Substitution, value: "r", destination: 2),
+			Edit(.Insertion, value: "t", destination: 2),
+			Edit(.Substitution, value: "r", destination: 4),
 		]
 		XCTAssertEqual(changeset.edits, edits)
 		
 		changeset = Changeset(source: "sword".characters, target: "words".characters)
 		edits = [
-			Edit(.Move(origin: 0), value: "s", destination: 5),
+			Edit(.Move(origin: 0), value: "s", destination: 4),
 		]
 		XCTAssertEqual(changeset.edits, edits)
 		
@@ -78,27 +78,18 @@ class ChangesetTests: XCTestCase {
 		]
 		XCTAssertEqual(changeset.edits, edits)
 		
-		changeset = Changeset(source: "ABCD".characters, target: "abcd".characters)
-		edits = [
-			Edit(.Substitution, value: "a", destination: 0),
-			Edit(.Substitution, value: "b", destination: 1),
-			Edit(.Substitution, value: "c", destination: 2),
-			Edit(.Substitution, value: "d", destination: 3),
-		]
-		XCTAssertEqual(changeset.edits, edits)
-		
 		// GARVEY -> AVERY (http://stackoverflow.com/a/30795531)
 		changeset = Changeset(source: "GARVEY".characters, target: "AVERY".characters)
 		edits = [
 			Edit(.Deletion, value: "G", destination: 0),
-			Edit(.Move(origin: 2), value: "R", destination: 5),
+			Edit(.Move(origin: 2), value: "R", destination: 3),
 		]
 		XCTAssertEqual(changeset.edits, edits)
 		
 		changeset = Changeset(source: "AVERY".characters, target: "GARVEY".characters)
 		edits = [
 			Edit(.Insertion, value: "G", destination: 0),
-			Edit(.Move(origin: 3), value: "R", destination: 1),
+			Edit(.Move(origin: 3), value: "R", destination: 2),
 		]
 		XCTAssertEqual(changeset.edits, edits)
 	}
@@ -164,18 +155,18 @@ class ChangesetTests: XCTestCase {
 		changeset = Changeset(source: "a".characters, target: "bac".characters)
 		edits = [
 			Edit(.Insertion, value: "b", destination: 0),
-			Edit(.Insertion, value: "c", destination: 1),
+			Edit(.Insertion, value: "c", destination: 2),
 		]
 		XCTAssertEqual(changeset.edits, edits)
 		
 		changeset = Changeset(source: "abcdef".characters, target: "aAbBcCdDeEfF".characters)
 		edits = [
 			Edit(.Insertion, value: "A", destination: 1),
-			Edit(.Insertion, value: "B", destination: 2),
-			Edit(.Insertion, value: "C", destination: 3),
-			Edit(.Insertion, value: "D", destination: 4),
-			Edit(.Insertion, value: "E", destination: 5),
-			Edit(.Insertion, value: "F", destination: 6),
+			Edit(.Insertion, value: "B", destination: 3),
+			Edit(.Insertion, value: "C", destination: 5),
+			Edit(.Insertion, value: "D", destination: 7),
+			Edit(.Insertion, value: "E", destination: 9),
+			Edit(.Insertion, value: "F", destination: 11),
 		]
 		XCTAssertEqual(changeset.edits, edits)
 	}
@@ -196,15 +187,15 @@ class ChangesetTests: XCTestCase {
 		
 		changeset = Changeset(source: "abbcdefgh".characters, target: "acdefgbbh".characters)
 		edits = [
-			Edit(.Move(origin: 1), value: "b", destination: 8),
-			Edit(.Move(origin: 2), value: "b", destination: 8),
+			Edit(.Move(origin: 1), value: "b", destination: 6),
+			Edit(.Move(origin: 2), value: "b", destination: 7),
 		]
 		XCTAssertEqual(changeset.edits, edits)
 		
 		changeset = Changeset(source: "acdefgbbh".characters, target: "abbcdefgh".characters)
 		edits = [
 			Edit(.Move(origin: 6), value: "b", destination: 1),
-			Edit(.Move(origin: 7), value: "b", destination: 1),
+			Edit(.Move(origin: 7), value: "b", destination: 2),
 		]
 		XCTAssertEqual(changeset.edits, edits)
 	}
@@ -236,7 +227,7 @@ class ChangesetTests: XCTestCase {
 		let changes = [
 			Edit(.Deletion, value: NSURL(string: "http://a.b.c")!, destination: 0),
 			Edit(.Deletion, value: NSURL(string: "http://k.l.m")!, destination: 2),
-			Edit(.Insertion, value: NSURL(string: "http://h.i.j")!, destination: 4),
+			Edit(.Insertion, value: NSURL(string: "http://h.i.j")!, destination: 2),
 		]
 		XCTAssertEqual(changeset.edits, changes)
 	}

--- a/ChangesetTests/ChangesetTests.swift
+++ b/ChangesetTests/ChangesetTests.swift
@@ -94,6 +94,44 @@ class ChangesetTests: XCTestCase {
 		XCTAssertEqual(changeset.edits, edits)
 	}
 	
+	func testInsertionsAfterDeletions() {
+		
+		var changeset: Changeset<String.CharacterView>
+		var edits: Array<Edit<String.CharacterView.Generator.Element>>
+		
+		changeset = Changeset(source: "abcdefgh".characters, target: "bdefijgh".characters)
+		edits = [
+			Edit(.Deletion, value: "a", destination: 0),
+			Edit(.Deletion, value: "c", destination: 2),
+			Edit(.Insertion, value: "i", destination: 4),
+			Edit(.Insertion, value: "j", destination: 5),
+		]
+		XCTAssertEqual(changeset.edits, edits)
+		
+		changeset = Changeset(source: "bdefijgh".characters, target: "abcdefgh".characters)
+		edits = [
+			Edit(.Insertion, value: "a", destination: 0),
+			Edit(.Insertion, value: "c", destination: 2),
+			Edit(.Deletion, value: "i", destination: 4),
+			Edit(.Deletion, value: "j", destination: 5),
+		]
+		XCTAssertEqual(changeset.edits, edits)
+		
+		changeset = Changeset(source: "abcdefgh".characters, target: "bdefagch".characters)
+		edits = [
+			Edit(.Move(origin: 0), value: "a", destination: 4),
+			Edit(.Move(origin: 2), value: "c", destination: 6),
+		]
+		XCTAssertEqual(changeset.edits, edits)
+		
+		changeset = Changeset(source: "bdefagch".characters, target: "abcdefgh".characters)
+		edits = [
+			Edit(.Move(origin: 4), value: "a", destination: 0),
+			Edit(.Move(origin: 6), value: "c", destination: 2),
+		]
+		XCTAssertEqual(changeset.edits, edits)
+	}
+	
 	func testEmptyStrings() {
 		
 		var changeset: Changeset<String.CharacterView>

--- a/ChangesetTests/ChangesetTests.swift
+++ b/ChangesetTests/ChangesetTests.swift
@@ -132,6 +132,33 @@ class ChangesetTests: XCTestCase {
 		XCTAssertEqual(changeset.edits, edits)
 	}
 	
+	func testListing7_8() {
+		
+		// https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/ManageInsertDeleteRow/ManageInsertDeleteRow.html#//apple_ref/doc/uid/TP40007451-CH10-SW16
+		
+		let changeset: Changeset<Array<String>>
+		let edits: Array<Edit<String>>
+		
+		let source = ["Arizona", "California", "Delaware", "New Jersey", "Washington"]
+		let target = ["Alaska", "Arizona", "California", "Georgia", "New Jersey", "Virginia"]
+		
+		/* In Apple's example the changeset consists of these five changes:
+		       Edit(.Insertion, value: "Alaska", destination: 0),
+		       Edit(.Deletion, value: "Delaware", destination: 2),
+		       Edit(.Insertion, value: "Georgia", destination: 3),
+		       Edit(.Deletion, value: "Washington", destination: 4),
+		       Edit(.Insertion, value: "Virginia", destination: 5),
+		   Changeset reduces this to the following three:*/
+		
+		changeset = Changeset(source: source, target: target)
+		edits = [
+			Edit(.Insertion, value: "Alaska", destination: 0),
+			Edit(.Substitution, value: "Georgia", destination: 3),
+			Edit(.Substitution, value: "Virginia", destination: 5),
+		]
+		XCTAssertEqual(changeset.edits, edits)
+	}
+	
 	func testDeLongTweet() {
 		
 		// https://twitter.com/davedelong/status/671051521371406336

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ let edits = [
 assert(changeset.edits == edits)
 ```
 
-Note that the indexes are into the original source collection.
+Because `Changeset` works on any `CollectionType` of `Equatable`, it has many applications. For example, it could be used to identify the changes needed to go from one array of elements to another, where the elements are instances of a custom `Equatable` class. This is particularly useful if these elements are displayed in a `UITableView`, and you want to animate a transition between two sets of data.
 
-Because `Changeset` works on any `CollectionType` of `Equatable`, it has many applications. For example, it could be used to identify the changes needed to go from one array of elements to another, where the elements are instances of a custom `Equatable` class.
+Note, indices are those exactly to be used within a `beginUpdates`/`endUpdates` block on `UITableView`.
 
-This is particularly useful if these elements are displayed in a `UITableView` and you want to animate a transition between two sets of data.
+In short; first all deletions are made relative to the source collection, then, relative to the resulting collection, insertions and substitutions. A move is just a deletion followed by an insertion on the resulting collection. This is explained in much more detail under [_Batch Insertion, Deletion, and Reloading of Rows and Sections_](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/ManageInsertDeleteRow/ManageInsertDeleteRow.html#//apple_ref/doc/uid/TP40007451-CH10-SW9) in Apple’s [Table View Programming Guide for iOS](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/AboutTableViewsiPhone/AboutTableViewsiPhone.html).
 
 If you don’t want the overhead of the `Changeset`, which stores the source and target collections, you can call `editDistance` directly:
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,15 @@ Note, indices are those exactly to be used within a `beginUpdates`/`endUpdates` 
 
 In short; first all deletions are made relative to the source collection, then, relative to the resulting collection, insertions and substitutions. A move is just a deletion followed by an insertion on the resulting collection. This is explained in much more detail under [_Batch Insertion, Deletion, and Reloading of Rows and Sections_](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/ManageInsertDeleteRow/ManageInsertDeleteRow.html#//apple_ref/doc/uid/TP40007451-CH10-SW9) in Apple’s [Table View Programming Guide for iOS](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/AboutTableViewsiPhone/AboutTableViewsiPhone.html).
 
-If you don’t want the overhead of the `Changeset`, which stores the source and target collections, you can call `editDistance` directly:
+If you don’t want the overhead of `Changeset` itself, which also stores the source and target collections, you can call `editDistance` directly (here with [example data](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/ManageInsertDeleteRow/ManageInsertDeleteRow.html#//apple_ref/doc/uid/TP40007451-CH10-SW16)) from Apple’s guide:
 
 ```swift
-let edits = Changeset.editDistance(source: "kitten".characters, target: "sitting".characters)
+let source = ["Arizona", "California", "Delaware", "New Jersey", "Washington"]
+let target = ["Alaska", "Arizona", "California", "Georgia", "New Jersey", "Virginia"]
+let edits = Changeset.editDistance(source: source, target: target)
 
 print(edits)
-// [replace with s at index 0, replace with i at index 4, insert g at index 6]
+// [insert Alaska at index 0, replace with Georgia at index 3, replace with Virginia at index 5]
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A `Changeset` describes the minimal edits required to go from one `CollectionType` of `Equatable` elements to another. It detects additions, deletions, substitutions, and moves.
 
-This is an attempt at implementing the solution outlined in [Dave DeLong](https://twitter.com/davedelong)’s article, [Edit distance and edit steps](http://davedelong.tumblr.com/post/134367865668/edit-distance-and-edit-steps).
+This is an attempt at implementing the solution outlined in [Dave DeLong](https://github.com/davedelong)’s article, [Edit distance and edit steps](http://davedelong.tumblr.com/post/134367865668/edit-distance-and-edit-steps).
 
 ## Usage
 


### PR DESCRIPTION
Fixes #2 by conforming to the principles outlined under [_Batch Insertion, Deletion, and Reloading of Rows and Sections_](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/ManageInsertDeleteRow/ManageInsertDeleteRow.html#//apple_ref/doc/uid/TP40007451-CH10-SW9) in Apple’s [Table View Programming Guide for iOS](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/AboutTableViewsiPhone/AboutTableViewsiPhone.html).
