### PR TITLE
Fix Substitution Indexes

### DIFF
--- a/Changeset.xcodeproj/project.pbxproj
+++ b/Changeset.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		29828DD41C2A899E0056284E /* Changeset.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 29828DC91C2A899D0056284E /* Changeset.framework */; };
 		29828DD91C2A899E0056284E /* ChangesetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29828DD81C2A899E0056284E /* ChangesetTests.swift */; };
 		29828DE41C2A8BD40056284E /* Changeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29828DE31C2A8BD40056284E /* Changeset.swift */; };
-		29828DE51C2A8BD40056284E /* Changeset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29828DE31C2A8BD40056284E /* Changeset.swift */; };
 		CC3454AA1C854BEF00CE0C4D /* TableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC3454A91C854BEF00CE0C4D /* TableViewController.swift */; };
 		CC4178681C6EE5E000296FD8 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC4178671C6EE5E000296FD8 /* AppDelegate.swift */; };
 		CC41786D1C6EE5E000296FD8 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CC41786B1C6EE5E000296FD8 /* Main.storyboard */; };
@@ -312,7 +311,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				29828DE51C2A8BD40056284E /* Changeset.swift in Sources */,
 				29828DD91C2A899E0056284E /* ChangesetTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Changeset/Changeset.swift
+++ b/Changeset/Changeset.swift
@@ -122,7 +122,7 @@ public struct Changeset<T: CollectionType where T.Generator.Element: Equatable, 
 						ins.append(insertion)
 						d[i][j] = ins
 					} else {
-						let substitution = Edit(.Substitution, value: t[tx], destination: j - 1)
+						let substitution = Edit(.Substitution, value: t[tx], destination: i - 1)
 						sub.append(substitution)
 						d[i][j] = sub
 					}

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Because `Changeset` works on any `CollectionType` of `Equatable`, it has many ap
 
 Note, indices are those exactly to be used within a `beginUpdates`/`endUpdates` block on `UITableView`.
 
-In short; first all deletions are made relative to the source collection, then, relative to the resulting collection, insertions and substitutions. A move is just a deletion followed by an insertion on the resulting collection. This is explained in much more detail under [_Batch Insertion, Deletion, and Reloading of Rows and Sections_](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/ManageInsertDeleteRow/ManageInsertDeleteRow.html#//apple_ref/doc/uid/TP40007451-CH10-SW9) in Apple’s [Table View Programming Guide for iOS](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/AboutTableViewsiPhone/AboutTableViewsiPhone.html).
+In short; first all deletions and substitutions are made, relative to the source collection, then, relative to the resulting collection, insertions. A move is just a deletion followed by an insertion. This is explained in more detail under [_Batch Insertion, Deletion, and Reloading of Rows and Sections_](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/ManageInsertDeleteRow/ManageInsertDeleteRow.html#//apple_ref/doc/uid/TP40007451-CH10-SW9) in Apple’s [Table View Programming Guide for iOS](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/AboutTableViewsiPhone/AboutTableViewsiPhone.html).
 
 If you don’t want the overhead of `Changeset` itself, which also stores the source and target collections, you can call `editDistance` directly (here with [example data](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/ManageInsertDeleteRow/ManageInsertDeleteRow.html#//apple_ref/doc/uid/TP40007451-CH10-SW16)) from Apple’s guide:
 
@@ -46,7 +46,7 @@ let target = ["Alaska", "Arizona", "California", "Georgia", "New Jersey", "Virgi
 let edits = Changeset.editDistance(source: source, target: target)
 
 print(edits)
-// [insert Alaska at index 0, replace with Georgia at index 3, replace with Virginia at index 5]
+// [insert Alaska at index 0, replace with Georgia at index 2, replace with Virginia at index 4]
 ```
   
 ## Test App

--- a/Test App/UIKit+Changeset.swift
+++ b/Test App/UIKit+Changeset.swift
@@ -19,7 +19,6 @@ extension UITableView {
 		if !indexPaths.deletions.isEmpty { self.deleteRowsAtIndexPaths(indexPaths.deletions, withRowAnimation: .Automatic) }
 		if !indexPaths.insertions.isEmpty { self.insertRowsAtIndexPaths(indexPaths.insertions, withRowAnimation: .Automatic) }
 		if !indexPaths.updates.isEmpty { self.reloadRowsAtIndexPaths(indexPaths.updates, withRowAnimation: .Automatic) }
-		indexPaths.moves.forEach { self.moveRowAtIndexPath($0.from, toIndexPath: $0.to) }
 		self.endUpdates()
 	}
 }
@@ -37,16 +36,14 @@ extension UICollectionView {
 			if !indexPaths.deletions.isEmpty { self.deleteItemsAtIndexPaths(indexPaths.deletions) }
 			if !indexPaths.insertions.isEmpty { self.insertItemsAtIndexPaths(indexPaths.insertions) }
 			if !indexPaths.updates.isEmpty { self.reloadItemsAtIndexPaths(indexPaths.updates) }
-			indexPaths.moves.forEach { self.moveItemAtIndexPath($0.from, toIndexPath: $0.to) }
 		}, completion: completion)
 	}
 }
 
-private func batchIndexPathsFromEdits<T: Equatable> (edits: [Edit<T>], inSection section: Int) -> (insertions: [NSIndexPath], deletions: [NSIndexPath], moves: [(from: NSIndexPath, to: NSIndexPath)], updates: [NSIndexPath]) {
+private func batchIndexPathsFromEdits<T: Equatable> (edits: [Edit<T>], inSection section: Int) -> (insertions: [NSIndexPath], deletions: [NSIndexPath], updates: [NSIndexPath]) {
 	
 	var insertions = [NSIndexPath]()
 	var deletions = [NSIndexPath]()
-	var moves = [(from: NSIndexPath, to: NSIndexPath)]()
 	var updates = [NSIndexPath]()
 	
 	for edit in edits {
@@ -58,11 +55,12 @@ private func batchIndexPathsFromEdits<T: Equatable> (edits: [Edit<T>], inSection
 			insertions.append(destinationIndexPath)
 		case .Move(let origin):
 			let originIndexPath = NSIndexPath(forRow: origin, inSection: section)
-			moves.append(from: originIndexPath, to: destinationIndexPath)
+			deletions.append(originIndexPath)
+			insertions.append(destinationIndexPath)
 		case .Substitution:
 			updates.append(destinationIndexPath)
 		}
 	}
 	
-	return (insertions: insertions, deletions: deletions, moves: moves, updates: updates)
+	return (insertions: insertions, deletions: deletions, updates: updates)
 }

--- a/Tests/ChangesetTests.swift
+++ b/Tests/ChangesetTests.swift
@@ -4,6 +4,7 @@
 //
 
 import XCTest
+import Changeset
 
 class ChangesetTests: XCTestCase {
 	

--- a/Tests/ChangesetTests.swift
+++ b/Tests/ChangesetTests.swift
@@ -45,7 +45,7 @@ class ChangesetTests: XCTestCase {
 		edits = [
 			Edit(.Deletion, value: "a", destination: 1),
 			Edit(.Deletion, value: "t", destination: 2),
-			Edit(.Substitution, value: "n", destination: 2),
+			Edit(.Substitution, value: "n", destination: 4),
 		]
 		XCTAssertEqual(changeset.edits, edits)
 		
@@ -53,7 +53,7 @@ class ChangesetTests: XCTestCase {
 		edits = [
 			Edit(.Insertion, value: "a", destination: 1),
 			Edit(.Insertion, value: "t", destination: 2),
-			Edit(.Substitution, value: "r", destination: 4),
+			Edit(.Substitution, value: "r", destination: 2),
 		]
 		XCTAssertEqual(changeset.edits, edits)
 		
@@ -141,7 +141,7 @@ class ChangesetTests: XCTestCase {
 		edits = [
 			Edit(.Move(origin: 1), value: "b", destination: 0),
 			Edit(.Deletion, value: "d", destination: 3),
-			Edit(.Substitution, value: "x", destination: 5),
+			Edit(.Substitution, value: "x", destination: 6),
 			Edit(.Insertion, value: "i", destination: 7),
 		]
 		XCTAssertEqual(changeset.edits, edits)
@@ -150,7 +150,7 @@ class ChangesetTests: XCTestCase {
 		edits = [
 			Edit(.Move(origin: 1), value: "a", destination: 0),
 			Edit(.Insertion, value: "d", destination: 3),
-			Edit(.Substitution, value: "g", destination: 6),
+			Edit(.Substitution, value: "g", destination: 5),
 			Edit(.Deletion, value: "i", destination: 7),
 		]
 		XCTAssertEqual(changeset.edits, edits)
@@ -177,8 +177,8 @@ class ChangesetTests: XCTestCase {
 		changeset = Changeset(source: source, target: target)
 		edits = [
 			Edit(.Insertion, value: "Alaska", destination: 0),
-			Edit(.Substitution, value: "Georgia", destination: 3),
-			Edit(.Substitution, value: "Virginia", destination: 5),
+			Edit(.Substitution, value: "Georgia", destination: 2),
+			Edit(.Substitution, value: "Virginia", destination: 4),
 		]
 		XCTAssertEqual(changeset.edits, edits)
 	}
@@ -206,8 +206,8 @@ class ChangesetTests: XCTestCase {
 		changeset = Changeset(source: "stick".characters, target: "tact".characters)
 		edits = [
 			Edit(.Deletion, value: "s", destination: 0),
-			Edit(.Substitution, value: "a", destination: 1),
-			Edit(.Substitution, value: "t", destination: 3),
+			Edit(.Substitution, value: "a", destination: 2),
+			Edit(.Substitution, value: "t", destination: 4),
 		]
 		XCTAssertEqual(changeset.edits, edits)
 		


### PR DESCRIPTION
Fixes #12 by correcting `.Substitution` indexes to point into the source collection as documented by Apple.

Related: `.Move` edit indexes are currently incompatible with table/collection view animation blocks. This would cause the test app to throw an exception. So instead of calling `moveRowAtIndexPath` and `moveItemAtIndexPath` with `.Move` indexes, moves are now composed by deletion/insertion pairs. This issue will be fixed separately.
