### PR TITLE
Fixed Swift 3.0 var params warnings

### DIFF
--- a/Changeset/Changeset.swift
+++ b/Changeset/Changeset.swift
@@ -142,8 +142,8 @@ public struct Changeset<T: CollectionType where T.Generator.Element: Equatable, 
 /// Returns an array where deletion/insertion pairs of the same element are replaced by `.Move` edits.
 private func reducedEdits<T: Equatable>(edits: [Edit<T>]) -> [Edit<T>] {
 	return edits.reduce([Edit<T>]()) {
-		(var reducedEdits, edit) in
-		
+		(edits, edit) in
+		var reducedEdits = edits
 		if let (move, index) = moveFromEdits(reducedEdits, deletionOrInsertion: edit), case .Move = move.operation {
 			reducedEdits.removeAtIndex(index)
 			reducedEdits.append(move)

--- a/Test App/DataSource.swift
+++ b/Test App/DataSource.swift
@@ -23,20 +23,20 @@ class DataSource {
 	private var data = kDefaultData
 	
 	/// The callback is called after each test to let the caller update its view, or whatever.
-	func runTests(var testData: [String] = kTestData, callback: ((edits: [Edit<Character>], isComplete: Bool) -> Void)) {
-		
-		let next = testData.removeAtIndex(0)
+	func runTests(testData: [String] = kTestData, callback: ((edits: [Edit<Character>], isComplete: Bool) -> Void)) {
+		var nextTestData = testData
+		let next = nextTestData.removeAtIndex(0)
 		let edits = Changeset.editDistance(source: self.data.characters, target: next.characters) // Call naiveEditDistance for a different approach
 		
 		self.data = next
-		callback(edits: edits, isComplete: testData.isEmpty)
+		callback(edits: edits, isComplete: nextTestData.isEmpty)
 		
-		guard !testData.isEmpty else { return }
+		guard !nextTestData.isEmpty else { return }
 		
 		// Schedule next test.
 		let when = dispatch_time(DISPATCH_TIME_NOW, Int64(kTestInterval * Double(NSEC_PER_SEC)))
 		dispatch_after(when, dispatch_get_main_queue()) {
-			self.runTests(testData, callback: callback)
+			self.runTests(nextTestData, callback: callback)
 		}
 	}
 	


### PR DESCRIPTION
var parameters have been deprecated in Swift 2.2 and will be removed in Swift 3.0 ([Swift proposal](https://github.com/apple/swift-evolution/blob/master/proposals/0003-remove-var-parameters.md)) Updated code to not use var params. This removes a couple compiler warnings and prepares for Swift 3.0.
