### PR TITLE
Add support for building the framework and test targets universally across all supported SDKs

### DIFF
--- a/Changeset.xcodeproj/project.pbxproj
+++ b/Changeset.xcodeproj/project.pbxproj
@@ -65,6 +65,8 @@
 		29828DDA1C2A899E0056284E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		29828DE31C2A8BD40056284E /* Changeset.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Changeset.swift; sourceTree = "<group>"; usesTabs = 1; };
 		29DB54B31C9DEEAB004A6DCE /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		9019C47D1D23AC8100A34C66 /* Universal-Framework-Target.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Universal-Framework-Target.xcconfig"; sourceTree = "<group>"; };
+		9019C47E1D23AC8100A34C66 /* Universal-Target-Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Universal-Target-Base.xcconfig"; sourceTree = "<group>"; };
 		CC3454A91C854BEF00CE0C4D /* TableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewController.swift; sourceTree = "<group>"; };
 		CC4178651C6EE5E000296FD8 /* Changeset.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Changeset.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC4178671C6EE5E000296FD8 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -112,6 +114,7 @@
 				29828DCB1C2A899D0056284E /* Sources */,
 				CC4178661C6EE5E000296FD8 /* Test App */,
 				29828DD71C2A899E0056284E /* Tests */,
+				9019C4791D23AC6600A34C66 /* Configuration */,
 				29828DCA1C2A899D0056284E /* Products */,
 			);
 			sourceTree = "<group>";
@@ -152,6 +155,15 @@
 				297DDB501C2BDDC9009EA889 /* Changeset.podspec */,
 			);
 			name = Packaging;
+			sourceTree = "<group>";
+		};
+		9019C4791D23AC6600A34C66 /* Configuration */ = {
+			isa = PBXGroup;
+			children = (
+				9019C47D1D23AC8100A34C66 /* Universal-Framework-Target.xcconfig */,
+				9019C47E1D23AC8100A34C66 /* Universal-Target-Base.xcconfig */,
+			);
+			path = Configuration;
 			sourceTree = "<group>";
 		};
 		CC4178661C6EE5E000296FD8 /* Test App */ = {
@@ -465,6 +477,7 @@
 		};
 		29828DDE1C2A899E0056284E /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9019C47D1D23AC8100A34C66 /* Universal-Framework-Target.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
@@ -482,6 +495,7 @@
 		};
 		29828DDF1C2A899E0056284E /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9019C47D1D23AC8100A34C66 /* Universal-Framework-Target.xcconfig */;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				DEFINES_MODULE = YES;
@@ -498,6 +512,7 @@
 		};
 		29828DE11C2A899E0056284E /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9019C47E1D23AC8100A34C66 /* Universal-Target-Base.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -508,6 +523,7 @@
 		};
 		29828DE21C2A899E0056284E /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 9019C47E1D23AC8100A34C66 /* Universal-Target-Base.xcconfig */;
 			buildSettings = {
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/Configuration/Universal-Framework-Target.xcconfig
+++ b/Configuration/Universal-Framework-Target.xcconfig
@@ -1,0 +1,25 @@
+#include "Universal-Target-Base.xcconfig"
+
+// OSX-specific default settings
+FRAMEWORK_VERSION[sdk=macosx*]                = A
+COMBINE_HIDPI_IMAGES[sdk=macosx*]             = YES
+
+// iOS-specific default settings
+TARGETED_DEVICE_FAMILY[sdk=iphonesimulator*]  = 1,2
+TARGETED_DEVICE_FAMILY[sdk=iphone*]           = 1,2
+
+// TV-specific default settings
+TARGETED_DEVICE_FAMILY[sdk=appletvsimulator*] = 3
+TARGETED_DEVICE_FAMILY[sdk=appletv*]          = 3
+
+// Watch-specific default settings
+TARGETED_DEVICE_FAMILY[sdk=watchsimulator*]   = 4
+TARGETED_DEVICE_FAMILY[sdk=watch*]            = 4
+
+ENABLE_BITCODE[sdk=macosx*]                   = NO
+ENABLE_BITCODE[sdk=watchsimulator*]           = YES
+ENABLE_BITCODE[sdk=watch*]                    = YES
+ENABLE_BITCODE[sdk=iphonesimulator*]          = NO
+ENABLE_BITCODE[sdk=iphone*]                   = YES
+ENABLE_BITCODE[sdk=appletvsimulator*]         = YES
+ENABLE_BITCODE[sdk=appletv*]                  = YES

--- a/Configuration/Universal-Target-Base.xcconfig
+++ b/Configuration/Universal-Target-Base.xcconfig
@@ -1,0 +1,21 @@
+SUPPORTED_PLATFORMS                    = macosx iphonesimulator iphoneos watchos watchsimulator appletvos appletvsimulator
+VALID_ARCHS[sdk=macosx*]               = i386 x86_64
+VALID_ARCHS[sdk=iphoneos*]             = arm64 armv7 armv7s
+VALID_ARCHS[sdk=iphonesimulator*]      = i386 x86_64
+VALID_ARCHS[sdk=watchos*]              = armv7k
+VALID_ARCHS[sdk=watchsimulator*]       = i386
+VALID_ARCHS[sdk=appletv*]              = arm64
+VALID_ARCHS[sdk=appletvsimulator*]     = x86_64
+
+// Dynamic linking uses different default copy paths
+LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]           = $(inherited) '@executable_path/../Frameworks' '@loader_path/../Frameworks'
+LD_RUNPATH_SEARCH_PATHS[sdk=iphoneos*]         = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'
+LD_RUNPATH_SEARCH_PATHS[sdk=iphonesimulator*]  = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'
+LD_RUNPATH_SEARCH_PATHS[sdk=watchos*]          = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'
+LD_RUNPATH_SEARCH_PATHS[sdk=watchsimulator*]   = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'
+LD_RUNPATH_SEARCH_PATHS[sdk=appletvos*]        = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'
+LD_RUNPATH_SEARCH_PATHS[sdk=appletvsimulator*] = $(inherited) '@executable_path/Frameworks' '@loader_path/Frameworks'
+
+IPHONEOS_DEPLOYMENT_TARGET = 8.0
+MACOSX_DEPLOYMENT_TARGET = 10.11
+TVOS_DEPLOYMENT_TARGET = 9.0


### PR DESCRIPTION
I'd love to use this with Carthage on my macOS projects, but the project was configured to provide iOS only (this is an Xcode limitation, I know). I've used the xcconfig approach in this PR on a few projects now, and it works quite well, but I'd understand any reluctance to merge it in. 

The main downside is that the iOS Test App now _thinks_ it can build on macOS and presents that option in the Xcode scheme switcher. Both the framework and tests can build across everything presented.
