### PR TITLE
Finalise Swift 3 migration

### DIFF
--- a/Changeset.xcodeproj/project.pbxproj
+++ b/Changeset.xcodeproj/project.pbxproj
@@ -429,6 +429,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -468,6 +469,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -490,7 +492,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -509,7 +510,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -521,7 +521,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = changeset.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -534,7 +533,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = changeset.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Sources/Changeset.swift
+++ b/Sources/Changeset.swift
@@ -34,7 +34,7 @@ public enum EditOperation {
 /// - note: This implementation was inspired by [Dave DeLong](https://twitter.com/davedelong)'s article, [Edit distance and edit steps](http://davedelong.tumblr.com/post/134367865668/edit-distance-and-edit-steps).
 ///
 /// - seealso: `Changeset.editDistance`.
-public struct Changeset<T: Collection where T.Iterator.Element: Equatable, T.IndexDistance == Int> {
+public struct Changeset<T: Collection> where T.Iterator.Element: Equatable, T.IndexDistance == Int {
 	
 	/// The starting-point collection.
 	public let origin: T

--- a/Tests/ChangesetTests.swift
+++ b/Tests/ChangesetTests.swift
@@ -389,8 +389,8 @@ extension Edit: CustomDebugStringConvertible {
 extension Changeset: CustomDebugStringConvertible {
 	public var debugDescription: String {
 		
-		let origin = self.origin.reduce("") { $0 + String($1) }
-		let destination = self.destination.reduce("") { $0 + String($1) }
+		let origin = self.origin.reduce("") { $0 + String(describing: $1) }
+		let destination = self.destination.reduce("") { $0 + String(describing: $1) }
 		
 		var text = "'\(origin)' -> '\(destination)':"
 		for change in self.edits {


### PR DESCRIPTION
Looks like a couple of minor items are required to finalise the Swift 3.0 migration under Xcode 8.0 and later. This PR addresses those.
