### PR TITLE
Add  to framework target

### DIFF
--- a/Changeset.xcodeproj/project.pbxproj
+++ b/Changeset.xcodeproj/project.pbxproj
@@ -265,6 +265,7 @@
 					29828DC81C2A899D0056284E = {
 						CreatedOnToolsVersion = 7.2;
 						LastSwiftMigration = 0800;
+						ProvisioningStyle = Automatic;
 					};
 					29828DD21C2A899E0056284E = {
 						CreatedOnToolsVersion = 7.2;


### PR DESCRIPTION
Provisioning style 'Automatic' is the most consumer friendly provisioning style for frameworks. It permits the host project to dictate the provisioning style. 
Otherwise if a host project specifies Manual provisioning style, xcodebuild will fail when attempting to compile the subproject with:

> Changeset does not support provisioning profiles. Changeset does not support provisioning profiles, but provisioning profile appstore_com.suppapp.ios has been manually specified. Set the provisioning profile value to "Automatic" in the build settings editor.
