### PR TITLE
Setting APPLICATION_EXTENSION_API_ONLY to YES

### DIFF
--- a/Changeset.xcodeproj/project.pbxproj
+++ b/Changeset.xcodeproj/project.pbxproj
@@ -394,6 +394,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -445,6 +446,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;


### PR DESCRIPTION
This allows `Changeset` to be used from within a framework, and outside of an application target,
avoiding this warning:
```
linking against a dylib which is not safe for use in application extensions: Changeset.framework/Changeset
```

