### PR TITLE
Allow table view row animation to be specified in UITableView convenience methods

### DIFF
--- a/Sources/UIKit+Changeset.swift
+++ b/Sources/UIKit+Changeset.swift
@@ -10,16 +10,16 @@ import UIKit
 extension UITableView {
 	
 	/// Performs batch updates on the table view, given the edits of a Changeset, and animates the transition.
-	open func update<T: Equatable>(with edits: [Edit<T>], in section: Int = 0) {
+	open func update<T: Equatable>(with edits: [Edit<T>], in section: Int = 0, with rowAnimation: UITableViewRowAnimation = .automatic) {
 		
 		guard !edits.isEmpty else { return }
 		
 		let indexPaths = batchIndexPaths(from: edits, in: section)
 		
 		self.beginUpdates()
-		if !indexPaths.deletions.isEmpty { self.deleteRows(at: indexPaths.deletions, with: .automatic) }
-		if !indexPaths.insertions.isEmpty { self.insertRows(at: indexPaths.insertions, with: .automatic) }
-		if !indexPaths.updates.isEmpty { self.reloadRows(at: indexPaths.updates, with: .automatic) }
+		if !indexPaths.deletions.isEmpty { self.deleteRows(at: indexPaths.deletions, with: rowAnimation) }
+		if !indexPaths.insertions.isEmpty { self.insertRows(at: indexPaths.insertions, with: rowAnimation) }
+		if !indexPaths.updates.isEmpty { self.reloadRows(at: indexPaths.updates, with: rowAnimation) }
 		self.endUpdates()
 	}
 }

--- a/Sources/UIKit+Changeset.swift
+++ b/Sources/UIKit+Changeset.swift
@@ -9,16 +9,16 @@ import UIKit
 extension UITableView {
 	
 	/// Performs batch updates on the table view, given the edits of a `Changeset`, and animates the transition.
-	open func update<C>(with edits: Array<Changeset<C>.Edit>, in section: Int = 0, with rowAnimation: UITableViewRowAnimation = .automatic) {
+	open func update<C>(with edits: Array<Changeset<C>.Edit>, in section: Int = 0, animation: UITableViewRowAnimation = .automatic) {
 		
 		guard !edits.isEmpty else { return }
 		
 		let indexPaths = batchIndexPaths(from: edits, in: section)
 		
 		self.beginUpdates()
-		if !indexPaths.deletions.isEmpty { self.deleteRows(at: indexPaths.deletions, with: rowAnimation) }
-		if !indexPaths.insertions.isEmpty { self.insertRows(at: indexPaths.insertions, with: rowAnimation) }
-		if !indexPaths.updates.isEmpty { self.reloadRows(at: indexPaths.updates, with: rowAnimation) }
+		if !indexPaths.deletions.isEmpty { self.deleteRows(at: indexPaths.deletions, with: animation) }
+		if !indexPaths.insertions.isEmpty { self.insertRows(at: indexPaths.insertions, with: animation) }
+		if !indexPaths.updates.isEmpty { self.reloadRows(at: indexPaths.updates, with: animation) }
 		self.endUpdates()
 	}
 }


### PR DESCRIPTION
Interestingly, the `.fade` animation looks significantly better than `.automatic` (videos below), which also aligns with my experience. I'm not opposed to making `.fade` the default, but understand if the consensus is that `.automatic` would be a more intuitive default for `Changeset` users.

`.fade`:
https://cl.ly/4334370Z3A1q/fade.mov

`.automatic`:
https://cl.ly/2y2U3Z122Q1q/automatic.mov