### PR TITLE
Use offset instead of index

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ print(edits)
 // [insert Alaska at offset 0, replace with Georgia at offset 2, replace with Virginia at offset 4]
 ```
 
-Note that Changeset uses offsets, not indexes, to refer to elements in the collections. This is mainly because Swift collections aren’t guranteed to use zero-based integers. See discussion in [issue #37](https://github.com/osteslag/Changeset/issues/37) for more details.
+Note that Changeset uses offsets, not indices, to refer to elements in the collections. This is mainly because Swift collections aren’t guaranteed to use zero-based integer indices. See discussion in [issue #37](https://github.com/osteslag/Changeset/issues/37) for more details.
 
 ## UIKit Integration
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ let changeset = Changeset(source: "kitten".characters, target: "sitting".charact
 
 print(changeset)
 // 'kitten' -> 'sitting':
-//     replace with s at index 0
-//     replace with i at index 4
-//     insert g at index 6
+//     replace with s at offset 0
+//     replace with i at offset 4
+//     insert g at offset 6
 ```
 
 The following assertion would then succeed:
@@ -42,12 +42,14 @@ let target = ["Alaska", "Arizona", "California", "Georgia", "New Jersey", "Virgi
 let edits = Changeset.edits(from: source, to: target)
 
 print(edits)
-// [insert Alaska at index 0, replace with Georgia at index 2, replace with Virginia at index 4]
+// [insert Alaska at offset 0, replace with Georgia at offset 2, replace with Virginia at offset 4]
 ```
+
+Note that Changeset uses offsets, not indexes, to refer to elements in the collections. This is mainly because Swift collections aren’t guranteed to use zero-based integers. See discussion in [issue #37](https://github.com/osteslag/Changeset/issues/37) for more details.
 
 ## UIKit Integration
 
-The index values can be used directly in the animation blocks of `beginUpdates`/`endUpdates` on `UITableView` and `performBatchUpdates` on `UICollectionView` in that `Changeset` follows the principles explained under [_Batch Insertion, Deletion, and Reloading of Rows and Sections_](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/ManageInsertDeleteRow/ManageInsertDeleteRow.html#//apple_ref/doc/uid/TP40007451-CH10-SW9) in Apple’s guide.
+The offset values can be used directly in the animation blocks of `beginUpdates`/`endUpdates` on `UITableView` and `performBatchUpdates` on `UICollectionView` in that `Changeset` follows the principles explained under [_Batch Insertion, Deletion, and Reloading of Rows and Sections_](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/ManageInsertDeleteRow/ManageInsertDeleteRow.html#//apple_ref/doc/uid/TP40007451-CH10-SW9) in Apple’s guide.
 
 In short; first all deletions and substitutions are made, relative to the source collection, then, relative to the resulting collection, insertions. A move is just a deletion followed by an insertion.
 

--- a/Sources/Changeset.swift
+++ b/Sources/Changeset.swift
@@ -6,20 +6,28 @@
 /// Defines an atomic edit.
 public struct Edit<T: Equatable> {
 	
+	/** The type used to refer to elements in the collections.
+	
+	Because not all collections are zero-based, let alone `Int`-based, an `Edit` uses *offsets* to elements in the collection. Offsets are the element counts from the first element in the collection.
+	
+	  - seealso: [Discussion on GitHub](https://github.com/osteslag/Changeset/issues/37).
+	*/
+	public typealias Offset = Int
+	
 	/// Defines the type of an `Edit`.
 	public enum Operation {
 		case insertion
 		case deletion
 		case substitution
-		case move(origin: Int)
+		case move(origin: Offset)
 	}
 	
 	public let operation: Operation
 	public let value: T
-	public let destination: Int
+	public let destination: Offset
 	
 	// Define initializer so that we don't have to add the `operation` label.
-	public init(_ operation: Operation, value: T, destination: Int) {
+	public init(_ operation: Operation, value: T, destination: Offset) {
 		self.operation = operation
 		self.value = value
 		self.destination = destination
@@ -34,7 +42,7 @@ It detects additions, deletions, substitutions, and moves. Data is a `Collection
 
   - seealso: `Changeset.editDistance`.
 */
-public struct Changeset<T: Collection> where T.Iterator.Element: Equatable, T.IndexDistance == Int {
+public struct Changeset<T: Collection> where T.Iterator.Element: Equatable, T.IndexDistance == Edit<T.Iterator.Element>.Offset {
 	
 	/// The starting-point collection.
 	public let origin: T
@@ -174,7 +182,7 @@ If `edit` is a deletion or an insertion, and there is a matching opposite insert
 
   - returns: An optional tuple consisting of the `.move` `Edit` that corresponds to the given deletion or insertion and an opposite match in `edits`, and the index of the match – if one was found.
 */
-private func move<T: Equatable>(from deletionOrInsertion: Edit<T>, `in` edits: [Edit<T>]) -> (move: Edit<T>, index: Int)? {
+private func move<T: Equatable>(from deletionOrInsertion: Edit<T>, `in` edits: [Edit<T>]) -> (move: Edit<T>, offset: Edit<T>.Offset)? {
 	
 	switch deletionOrInsertion.operation {
 		

--- a/Sources/Changeset.swift
+++ b/Sources/Changeset.swift
@@ -8,7 +8,7 @@ public struct Edit<T: Equatable> {
 	
 	/** The type used to refer to elements in the collections.
 	
-	Because not all collections are zero-based, let alone `Int`-based, an `Edit` uses *offsets* to elements in the collection. Offsets are the element counts from the first element in the collection.
+	Because not all collection indices are zero-based, let alone `Int`-based, an `Edit` uses *offsets* to elements in the collection. Offsets are the element counts from the first element in the collection.
 	
 	  - seealso: [Discussion on GitHub](https://github.com/osteslag/Changeset/issues/37).
 	*/

--- a/Test App/Changeset+Naive.swift
+++ b/Test App/Changeset+Naive.swift
@@ -12,20 +12,20 @@ extension Changeset {
 		
 		var rv:[Edit<T.Generator.Element>] = []
 		
-		for (oldIndex, item) in s.enumerated() {
-			guard let newIndex = t.index(of: item) else {
-				rv.append(Edit(.deletion, value:item, destination:oldIndex))
+		for (oldOffset, item) in s.enumerated() {
+			guard let newOffset = t.index(of: item) else {
+				rv.append(Edit(.deletion, value:item, destination:oldOffset))
 				continue
 			}
-			let newIndexI = t.distance(from: t.startIndex, to: newIndex)
-			if newIndexI != oldIndex {
-				rv.append(Edit(.move(origin: oldIndex), value:item, destination:newIndexI))
+			let newOffsetI = t.distance(from: t.startIndex, to: newOffset)
+			if newOffsetI != oldOffset {
+				rv.append(Edit(.move(origin: oldOffset), value:item, destination:newOffsetI))
 			}
 		}
 		
-		for (newIndex, item) in t.enumerated() {
+		for (newOffset, item) in t.enumerated() {
 			if !s.contains(item) {
-				rv.append(Edit(.insertion, value:item, destination:newIndex))
+				rv.append(Edit(.insertion, value:item, destination:newOffset))
 			}
 		}
 		

--- a/Tests/ChangesetTests.swift
+++ b/Tests/ChangesetTests.swift
@@ -375,13 +375,13 @@ extension Edit: CustomDebugStringConvertible {
 	public var debugDescription: String {
 		switch self.operation {
 		case .insertion:
-			return "insert \(self.value) at index \(self.destination)"
+			return "insert \(self.value) at offset \(self.destination)"
 		case .deletion:
-			return "delete \(self.value) at index \(self.destination)"
+			return "delete \(self.value) at offset \(self.destination)"
 		case .substitution:
-			return "replace with \(self.value) at index \(self.destination)"
+			return "replace with \(self.value) at offset \(self.destination)"
 		case .move(let origin):
-			return "move \(self.value) from index \(origin) to \(self.destination)"
+			return "move \(self.value) from offset \(origin) to \(self.destination)"
 		}
 	}
 }


### PR DESCRIPTION
Hi @ole,

I hope you have time to review this PR which closes #37 where you argue for the use of an *offset* naming instead of *index*.

The meat of it is in the 990e8ae20f8ae14b9905e757414e86bf5499bc01 commit which introduces the `Edit.Offset` `typealias`, motivated in the commit message by:

> A `typealias`, and not a strong type, was chosen because it still clearly communicates what it is while preserving the meaning of a count and recognising the underlying type of the various collections is still just an `Int`.

Notice the PR merges into a `version-3` branch I’m preparing, where I was finally able to move `Operation` in under `Edit` and other little things.