### PR TITLE
Make Edit a type of a Collection

### DIFF
--- a/Sources/Changeset.swift
+++ b/Sources/Changeset.swift
@@ -160,7 +160,7 @@ public struct Changeset<T: Collection> where T.Iterator.Element: Equatable, T.In
   - parameter edits: An array of `Edit` elements to be reduced.
   - returns: An array of `Edit` elements.
 */
-private func reducedEdits<T: Collection>(_ edits: [Edit<T>]) -> [Edit<T>] {
+private func reducedEdits<T>(_ edits: [Edit<T>]) -> [Edit<T>] {
 	return edits.reduce([Edit<T>]()) { (edits, edit) in
 		var reducedEdits = edits
 		if let (move, offset) = move(from: edit, in: reducedEdits), case .move = move.operation {
@@ -184,7 +184,7 @@ If `edit` is a deletion or an insertion, and there is a matching opposite insert
 
   - returns: An optional tuple consisting of the `.move` `Edit` that corresponds to the given deletion or insertion and an opposite match in `edits`, and the offset of the match – if one was found.
 */
-private func move<T: Collection>(from deletionOrInsertion: Edit<T>, `in` edits: [Edit<T>]) -> (move: Edit<T>, offset: Edit<T>.Offset)? {
+private func move<T>(from deletionOrInsertion: Edit<T>, `in` edits: [Edit<T>]) -> (move: Edit<T>, offset: Edit<T>.Offset)? {
 	
 	switch deletionOrInsertion.operation {
 		
@@ -210,7 +210,7 @@ private func move<T: Collection>(from deletionOrInsertion: Edit<T>, `in` edits: 
 }
 
 extension Edit: Equatable {}
-public func ==<T: Collection>(lhs: Edit<T>, rhs: Edit<T>) -> Bool {
+public func ==<T>(lhs: Edit<T>, rhs: Edit<T>) -> Bool {
 	guard lhs.destination == rhs.destination && lhs.value == rhs.value else { return false }
 	switch (lhs.operation, rhs.operation) {
 	case (.insertion, .insertion), (.deletion, .deletion), (.substitution, .substitution):

--- a/Sources/UIKit+Changeset.swift
+++ b/Sources/UIKit+Changeset.swift
@@ -9,8 +9,8 @@ import UIKit
 
 extension UITableView {
 	
-	/// Performs batch updates on the table view, given the edits of a Changeset, and animates the transition.
-	open func update<T: Equatable>(with edits: [Edit<T>], in section: Int = 0) {
+	/// Performs batch updates on the table view, given the edits of a `Changeset`, and animates the transition.
+	open func update<T: Collection>(with edits: [Edit<T>], in section: Int = 0) {
 		
 		guard !edits.isEmpty else { return }
 		
@@ -26,8 +26,8 @@ extension UITableView {
 
 extension UICollectionView {
 	
-	/// Performs batch updates on the table view, given the edits of a Changeset, and animates the transition.
-	open func update<T: Equatable>(with edits: [Edit<T>], in section: Int = 0, completion: ((Bool) -> Void)? = nil) {
+	/// Performs batch updates on the table view, given the edits of a `Changeset`, and animates the transition.
+	open func update<T: Collection>(with edits: [Edit<T>], in section: Int = 0, completion: ((Bool) -> Void)? = nil) {
 		
 		guard !edits.isEmpty else { return }
 		
@@ -41,7 +41,7 @@ extension UICollectionView {
 	}
 }
 
-private func batchIndexPaths<T: Equatable> (from edits: [Edit<T>], in section: Int) -> (insertions: [IndexPath], deletions: [IndexPath], updates: [IndexPath]) {
+private func batchIndexPaths<T: Collection> (from edits: [Edit<T>], in section: Int) -> (insertions: [IndexPath], deletions: [IndexPath], updates: [IndexPath]) {
 	
 	var insertions = [IndexPath]()
 	var deletions = [IndexPath]()

--- a/Sources/UIKit+Changeset.swift
+++ b/Sources/UIKit+Changeset.swift
@@ -10,7 +10,7 @@ import UIKit
 extension UITableView {
 	
 	/// Performs batch updates on the table view, given the edits of a `Changeset`, and animates the transition.
-	open func update<T: Collection>(with edits: [Edit<T>], in section: Int = 0) {
+	open func update<T>(with edits: [Edit<T>], in section: Int = 0) {
 		
 		guard !edits.isEmpty else { return }
 		
@@ -27,7 +27,7 @@ extension UITableView {
 extension UICollectionView {
 	
 	/// Performs batch updates on the table view, given the edits of a `Changeset`, and animates the transition.
-	open func update<T: Collection>(with edits: [Edit<T>], in section: Int = 0, completion: ((Bool) -> Void)? = nil) {
+	open func update<T>(with edits: [Edit<T>], in section: Int = 0, completion: ((Bool) -> Void)? = nil) {
 		
 		guard !edits.isEmpty else { return }
 		
@@ -41,7 +41,7 @@ extension UICollectionView {
 	}
 }
 
-private func batchIndexPaths<T: Collection> (from edits: [Edit<T>], in section: Int) -> (insertions: [IndexPath], deletions: [IndexPath], updates: [IndexPath]) {
+private func batchIndexPaths<T> (from edits: [Edit<T>], in section: Int) -> (insertions: [IndexPath], deletions: [IndexPath], updates: [IndexPath]) {
 	
 	var insertions = [IndexPath]()
 	var deletions = [IndexPath]()

--- a/Test App/Changeset+Naive.swift
+++ b/Test App/Changeset+Naive.swift
@@ -8,9 +8,9 @@ import Changeset
 
 extension Changeset {
 	
-	public static func naiveEditDistance(source s: T, target t: T) -> [Edit<T.Iterator.Element>] {
+	public static func naiveEditDistance(source s: T, target t: T) -> [Edit<T>] {
 		
-		var rv:[Edit<T.Generator.Element>] = []
+		var rv: [Edit<T>] = []
 		
 		for (oldOffset, item) in s.enumerated() {
 			guard let newOffset = t.index(of: item) else {

--- a/Test App/CollectionViewController.swift
+++ b/Test App/CollectionViewController.swift
@@ -12,7 +12,7 @@ class CollectionViewController: UICollectionViewController {
 	
 	@IBAction func test(_ sender: UIBarButtonItem) {
 		self.dataSource.runTests() {
-			(edits: [Edit<Character>], isComplete: Bool) in
+			(edits: [Edit<String.CharacterView>], isComplete: Bool) in
 			self.collectionView?.update(with: edits)
 			sender.isEnabled = isComplete
 		}

--- a/Test App/DataSource.swift
+++ b/Test App/DataSource.swift
@@ -23,7 +23,7 @@ class DataSource {
 	fileprivate var data = kDefaultData
 	
 	/// The callback is called after each test to let the caller update its view, or whatever.
-	func runTests(_ testData: [String] = kTestData, callback: @escaping ((_ edits: [Edit<Character>], _ isComplete: Bool) -> Void)) {
+	func runTests(_ testData: [String] = kTestData, callback: @escaping ((_ edits: [Edit<String.CharacterView>], _ isComplete: Bool) -> Void)) {
 		var nextTestData = testData
 		let next = nextTestData.remove(at: 0)
 		let edits = Changeset.edits(from: self.data.characters, to: next.characters) // Call naiveEditDistance for a different approach

--- a/Test App/TableViewController.swift
+++ b/Test App/TableViewController.swift
@@ -12,7 +12,7 @@ class TableViewController: UITableViewController {
 	
 	@IBAction func test(_ sender: UIBarButtonItem) {
 		self.dataSource.runTests() {
-			(edits: [Edit<Character>], isComplete: Bool) in
+			(edits: [Edit<String.CharacterView>], isComplete: Bool) in
 			self.tableView.update(with: edits)
 			sender.isEnabled = isComplete
 		}

--- a/Tests/ChangesetTests.swift
+++ b/Tests/ChangesetTests.swift
@@ -25,7 +25,7 @@ class ChangesetTests: XCTestCase {
 	func testSampleChanges() {
 		
 		var changeset: Changeset<String.CharacterView>
-		var edits: Array<Edit<String.CharacterView.Generator.Element>>
+		var edits: Array<Edit<String.CharacterView>>
 		
 		changeset = Changeset(source: "kitten".characters, target: "sitting".characters)
 		edits = [
@@ -99,7 +99,7 @@ class ChangesetTests: XCTestCase {
 	func testInsertionsAfterDeletions() {
 		
 		var changeset: Changeset<String.CharacterView>
-		var edits: Array<Edit<String.CharacterView.Generator.Element>>
+		var edits: Array<Edit<String.CharacterView>>
 		
 		changeset = Changeset(source: "abcdefgh".characters, target: "bdefijgh".characters)
 		edits = [
@@ -137,7 +137,7 @@ class ChangesetTests: XCTestCase {
 	func testComplexChange() {
 		
 		var changeset: Changeset<String.CharacterView>
-		var edits: Array<Edit<String.CharacterView.Generator.Element>>
+		var edits: Array<Edit<String.CharacterView>>
 		
 		changeset = Changeset(source: "abcdefgh".characters, target: "bacefxhi".characters)
 		edits = [
@@ -163,7 +163,7 @@ class ChangesetTests: XCTestCase {
 		// https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/ManageInsertDeleteRow/ManageInsertDeleteRow.html#//apple_ref/doc/uid/TP40007451-CH10-SW16
 		
 		let changeset: Changeset<Array<String>>
-		let edits: Array<Edit<String>>
+		let edits: Array<Edit<Array<String>>>
 		
 		let source = ["Arizona", "California", "Delaware", "New Jersey", "Washington"]
 		let target = ["Alaska", "Arizona", "California", "Georgia", "New Jersey", "Virginia"]
@@ -190,7 +190,7 @@ class ChangesetTests: XCTestCase {
 		// https://twitter.com/davedelong/status/671051521371406336
 		
 		var changeset: Changeset<String.CharacterView>
-		var edits: Array<Edit<String.CharacterView.Generator.Element>>
+		var edits: Array<Edit<String.CharacterView>>
 		
 		changeset = Changeset(source: "words".characters, target: "tsword".characters)
 		edits = [
@@ -233,7 +233,7 @@ class ChangesetTests: XCTestCase {
 	func testEmptyStrings() {
 		
 		var changeset: Changeset<String.CharacterView>
-		var edits: Array<Edit<String.CharacterView.Generator.Element>>
+		var edits: Array<Edit<String.CharacterView>>
 		
 		changeset = Changeset(source: "abc".characters, target: "".characters)
 		edits = [
@@ -255,7 +255,7 @@ class ChangesetTests: XCTestCase {
 	func testOneElementChanges() {
 		
 		var changeset: Changeset<String.CharacterView>
-		var edits: Array<Edit<String.CharacterView.Generator.Element>>
+		var edits: Array<Edit<String.CharacterView>>
 		
 		changeset = Changeset(source: " ".characters, target: "a".characters)
 		edits = [
@@ -273,7 +273,7 @@ class ChangesetTests: XCTestCase {
 	func testInsertions() {
 		
 		var changeset: Changeset<String.CharacterView>
-		var edits: Array<Edit<String.CharacterView.Generator.Element>>
+		var edits: Array<Edit<String.CharacterView>>
 		
 		changeset = Changeset(source: "".characters, target: "a".characters)
 		edits = [
@@ -310,7 +310,7 @@ class ChangesetTests: XCTestCase {
 	func testMoves() {
 		
 		var changeset: Changeset<String.CharacterView>
-		var edits: Array<Edit<String.CharacterView.Generator.Element>>
+		var edits: Array<Edit<String.CharacterView>>
 		
 		changeset = Changeset(source: "AAAAaaaa".characters, target: "aaaaAAAA".characters)
 		edits = [
@@ -361,9 +361,9 @@ class ChangesetTests: XCTestCase {
 		
 		let changeset = Changeset(source: old, target: new)
 		let changes = [
-			Edit(.deletion, value: URL(string: "http://a.b.c")!, destination: 0),
-			Edit(.deletion, value: URL(string: "http://k.l.m")!, destination: 2),
-			Edit(.insertion, value: URL(string: "http://h.i.j")!, destination: 2),
+			Edit<Array<URL>>(.deletion, value: old[0], destination: 0),
+			Edit(.deletion, value: old[2], destination: 2),
+			Edit(.insertion, value: new[2], destination: 2),
 		]
 		XCTAssertEqual(changeset.edits, changes)
 	}


### PR DESCRIPTION
This set of changes is about making `Edit` a type of a *collection* instead of a collection’s *equatable elements* plus the resulting changed requirements, including tests and test app. Merges into the version 3 branch.

An `Edit` needs to have a concept of the collection type so we can ensure we can do arithmetic on the collection’s index distance type, see [discussion](https://github.com/osteslag/Changeset/pull/39#discussion_r129030599) on #39.

I wasn’t able to declare `…where C.IndexDistance: SignedInteger` on `Edit`, `Changeset` while doing enumerations and additions/subtractions on offsets in a compatible way. At least I couldn’t figure out how to. So for now, we require `Int` index distances on the collections.

Note: I prefer to ensure all commits are compilable (`git-bisect`), hence all files in one commit.

FYI: I’m planning a general cleanup for version 3 (including using the `C` shorthand for `Collection` types, probably splitting up `Edit` and `Changeset` in separate files).