### PR TITLE
[Do not merge] Remove IndexDistance constraint on Changeset and Edit

### DIFF
--- a/Sources/UIKit+Changeset.swift
+++ b/Sources/UIKit+Changeset.swift
@@ -48,14 +48,14 @@ private func batchIndexPaths<T: Collection> (from edits: [Edit<T>], in section: 
 	var updates = [IndexPath]()
 	
 	for edit in edits {
-		let destinationIndexPath = IndexPath(row: edit.destination, section: section)
+		let destinationIndexPath = IndexPath(row: Int(edit.destination.toIntMax()), section: section)
 		switch edit.operation {
 		case .deletion:
 			deletions.append(destinationIndexPath)
 		case .insertion:
 			insertions.append(destinationIndexPath)
 		case .move(let origin):
-			let originIndexPath = IndexPath(row: origin, section: section)
+			let originIndexPath = IndexPath(row: Int(origin.toIntMax()), section: section)
 			deletions.append(originIndexPath)
 			insertions.append(destinationIndexPath)
 		case .substitution:


### PR DESCRIPTION
This removes the constraint on Collection.IndexDistance on `Changeset` and `Edit`. Conversions between integer types are a little annoying in Swift, especially in Swift 3. Before the revamp of the integer protocols in [SE-0104], we have to go through `IntMax` to convert between integer types. We should be able to remove the `toIntMax()` calls when we drop Swift 3 support.

More importantly, while this code currently compiles, it crashes with this runtime error when running the unit tests:

> GenericCache(0x114050798): cyclic metadata dependency detected, aborting

The same crash happens in Xcode 8.3.2 and Xcode 9b4 (Swift 3 mode; I haven't checked if it was fixed in Swift 4).

Related bugs:
- [SR-4383]
- [SR-4732]
- [SR-5068]

The crash has something to do with nested generic type metadata. As suggested in one of the issues on JIRA, the crash goes away if we make the enum inside Edit indirect:

```swift
public struct Edit<C: Collection> where C.Iterator.Element: Equatable {
    ...

    indirect public enum Operation {
        ...
    }
    ...
```

I don't know if this is supposed to be a final fix or just a workaround and this issue will eventually be fixed.

Until then, it's probably not worth merging this since the `IndexDistance == Int` constraint is not a very big deal in practice. But I wanted a place to show you the changes that would be needed, that's why I opened this PR.

[SE-0104]: https://github.com/apple/swift-evolution/blob/master/proposals/0104-improved-integers.md
[SR-4383]: https://bugs.swift.org/browse/SR-4383
[SR-4732]: https://bugs.swift.org/browse/SR-4732
[SR-5068]: https://bugs.swift.org/browse/SR-5086