### PR TITLE
Custom comparator

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,28 +61,28 @@ tableView.update(with: changeset.edits)
 
 ## Custom Comparator
 
-By default `Changeset` uses `==` to compare. It is possible to change the comparator:
+By default a `Changeset` uses `==` to compare elements, but you can write your own comparator, illustrated below, where the occurence of an “a” always triggers a change:
 
 ```swift
 let alwaysChangeA: (Character, Character) -> Bool = {
-  if $0 == "a" || $1 == "a" {
-    return false
-  } else {
-    return $0 == $1
-  }
+    if $0 == "a" || $1 == "a" {
+        return false
+    } else {
+        return $0 == $1
+    }
 }
 let changeset = Changeset(source: "ab", target: "ab", comparator: alwaysChangeA)
 ```
 
-The following assertion would then succeed:
+As a result, the changeset will consist of a substitution of the “a” (to another “a”):
 
 ```swift
-let edits: [Changeset<String>.Edit] = [Changeset.Edit(operation: .substitution, value: "a", destination: 0)]
-assert(changeset.edits == edits)
+let expectedEdits: [Changeset<String>.Edit] = [Changeset.Edit(operation: .substitution, value: "a", destination: 0)]
+assert(changeset.edits == expectedEdits)
 ```
 
-One use of this is when a cell in a `UITableView` or `UICollectionView` shouldn't animate when they change.
-  
+One possible use of this is when a cell in a `UITableView` or `UICollectionView` shouldn’t animate when they change.
+
 ## Test App
 
 The Xcode project also contains a target to illustrate the usage in an app:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,30 @@ In the iOS framework, two convenience extensions (one on `UITableView` and one o
 ```swift
 tableView.update(with: changeset.edits)
 ```
+
+## Custom Comparator
+
+By default `Changeset` uses `==` to compare. It is possible to change the comparator:
+
+```swift
+let alwaysChangeA: (Character, Character) -> Bool = {
+  if $0 == "a" || $1 == "a" {
+    return false
+  } else {
+    return $0 == $1
+  }
+}
+let changeset = Changeset(source: "ab", target: "ab", comparator: alwaysChangeA)
+```
+
+The following assertion would then succeed:
+
+```swift
+let edits: [Changeset<String>.Edit] = [Changeset.Edit(operation: .substitution, value: "a", destination: 0)]
+assert(changeset.edits == edits)
+```
+
+One use of this is when a cell in a `UITableView` or `UICollectionView` shouldn't animate when they change.
   
 ## Test App
 

--- a/Sources/Changeset.swift
+++ b/Sources/Changeset.swift
@@ -12,7 +12,10 @@ It detects additions, deletions, substitutions, and moves. Data is a `Collection
   - seealso: `Changeset.edits`.
 */
 public struct Changeset<C: Collection> where C.Iterator.Element: Equatable, C.IndexDistance == Int {
-	
+
+	/// Closure type to compare two values
+	public typealias Comparator = (C.Iterator.Element, C.Iterator.Element) -> Bool
+
 	/// The starting-point collection.
 	public let origin: C
 	
@@ -27,10 +30,10 @@ public struct Changeset<C: Collection> where C.Iterator.Element: Equatable, C.In
 	*/
 	public let edits: Array<Edit>
 	
-	public init(source origin: C, target destination: C) {
+	public init(source origin: C, target destination: C, comparator: Comparator = (==)) {
 		self.origin = origin
 		self.destination = destination
-		self.edits = Changeset.edits(from: self.origin, to: self.destination)
+		self.edits = Changeset.edits(from: self.origin, to: self.destination, comparator: comparator)
 	}
 	
 	/** Returns the edit steps required to go from one collection to another.
@@ -46,10 +49,11 @@ public struct Changeset<C: Collection> where C.Iterator.Element: Equatable, C.In
 	  - parameters:
 	    - from: The starting-point collection.
 	    - to: The ending-point collection.
+			- comparator: The comparision function to use
 	
 	  - returns: An array of `Edit` elements.
 	*/
-	public static func edits(from source: C, to target: C) -> Array<Edit> {
+	public static func edits(from source: C, to target: C, comparator: Comparator = (==)) -> Array<Edit> {
 		
 		let rows = source.count
 		let columns = target.count
@@ -84,7 +88,7 @@ public struct Changeset<C: Collection> where C.Iterator.Element: Equatable, C.In
 				
 				if columns > 0 {
 					for column in 1...columns {
-						if source[sourceOffset] == target[targetOffset] {
+						if comparator(source[sourceOffset], target[targetOffset]) {
 							currentRow[column] = previousRow[column - 1] // no operation
 						} else {
 							var deletion = previousRow[column] // a deletion
@@ -118,6 +122,6 @@ public struct Changeset<C: Collection> where C.Iterator.Element: Equatable, C.In
 		}
 		
 		// Convert deletion/insertion pairs of same element into moves.
-		return Changeset.reducedEdits(previousRow[columns])
+		return Changeset.reducedEdits(previousRow[columns], comparator: comparator)
 	}
 }

--- a/Sources/Changeset.swift
+++ b/Sources/Changeset.swift
@@ -12,8 +12,8 @@ It detects additions, deletions, substitutions, and moves. Data is a `Collection
   - seealso: `Changeset.edits`.
 */
 public struct Changeset<C: Collection> where C.Iterator.Element: Equatable, C.IndexDistance == Int {
-
-	/// Closure type to compare two values
+	
+	/// Closure used to compare two elements.
 	public typealias Comparator = (C.Iterator.Element, C.Iterator.Element) -> Bool
 
 	/// The starting-point collection.
@@ -49,7 +49,7 @@ public struct Changeset<C: Collection> where C.Iterator.Element: Equatable, C.In
 	  - parameters:
 	    - from: The starting-point collection.
 	    - to: The ending-point collection.
-			- comparator: The comparision function to use
+	    - comparator: The comparision function to use.
 	
 	  - returns: An array of `Edit` elements.
 	*/

--- a/Tests/ChangesetTests.swift
+++ b/Tests/ChangesetTests.swift
@@ -389,6 +389,27 @@ class ChangesetTests: XCTestCase {
 		]
 		XCTAssertEqual(changeset.edits, changes)
 	}
+
+	func testCustomComparator() {
+		let dontCareAbouA: (Character, Character) -> Bool = {
+			if $0 == "a" || $1 == "a" {
+				return true
+			} else {
+				return $0 == $1
+			}
+		}
+		XCTAssertEqual([], Changeset(source: "ab", target: "bb", comparator: dontCareAbouA).edits)
+
+		let alwaysChangeA: (Character, Character) -> Bool = {
+			if $0 == "a" || $1 == "a" {
+				return false
+			} else {
+				return $0 == $1
+			}
+		}
+		let edits: [Changeset<String>.Edit] = [Changeset.Edit(operation: .substitution, value: "a", destination: 0)]
+		XCTAssertEqual(edits, Changeset(source: "ab", target: "ab", comparator: alwaysChangeA).edits)
+	}
 }
 
 // MARK: -

--- a/Tests/ChangesetTests.swift
+++ b/Tests/ChangesetTests.swift
@@ -391,15 +391,16 @@ class ChangesetTests: XCTestCase {
 	}
 
 	func testCustomComparator() {
-		let dontCareAbouA: (Character, Character) -> Bool = {
+		
+		let neverChangeA: (Character, Character) -> Bool = {
 			if $0 == "a" || $1 == "a" {
 				return true
 			} else {
 				return $0 == $1
 			}
 		}
-		XCTAssertEqual([], Changeset(source: "ab", target: "bb", comparator: dontCareAbouA).edits)
-
+		XCTAssertEqual([], Changeset(source: "ab", target: "bb", comparator: neverChangeA).edits)
+		
 		let alwaysChangeA: (Character, Character) -> Bool = {
 			if $0 == "a" || $1 == "a" {
 				return false
@@ -407,8 +408,8 @@ class ChangesetTests: XCTestCase {
 				return $0 == $1
 			}
 		}
-		let edits: [Changeset<String>.Edit] = [Changeset.Edit(operation: .substitution, value: "a", destination: 0)]
-		XCTAssertEqual(edits, Changeset(source: "ab", target: "ab", comparator: alwaysChangeA).edits)
+		let expectedEdits: [Changeset<String>.Edit] = [Changeset.Edit(operation: .substitution, value: "a", destination: 0)]
+		XCTAssertEqual(expectedEdits, Changeset(source: "ab", target: "ab", comparator: alwaysChangeA).edits)
 	}
 }
 


### PR DESCRIPTION
Add the ability to use a different operator for comparison. This is essentially a re-implementation of the work done by @pomozoff in #28. I set out to resolve the merge conflicts but discovered that it was easier to manually re-apply the changes. I also added tests.

I updated the README as well, but am open to better examples and suggestions on how to explain this better.