### PR TITLE
Change Offset to Int type

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ print(edits)
 // [insert Alaska at offset 0, replace with Georgia at offset 2, replace with Virginia at offset 4]
 ```
 
-Note that Changeset uses offsets, not indices, to refer to elements in the collections. This is mainly because Swift collections aren’t guaranteed to use zero-based integer indices. See discussion in [issue #37](https://github.com/osteslag/Changeset/issues/37) for more details.
-
 ## UIKit Integration
 
 The offset values can be used directly in the animation blocks of `beginUpdates`/`endUpdates` on `UITableView` and `performBatchUpdates` on `UICollectionView` in that `Changeset` follows the principles explained under [_Batch Insertion, Deletion, and Reloading of Rows and Sections_](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/ManageInsertDeleteRow/ManageInsertDeleteRow.html#//apple_ref/doc/uid/TP40007451-CH10-SW9) in Apple’s guide.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ print(edits)
 // [insert Alaska at offset 0, replace with Georgia at offset 2, replace with Virginia at offset 4]
 ```
 
+Note that Changeset uses offsets, not indices, to refer to elements in the collections. This is mainly because Swift collections aren’t guaranteed to use zero-based integer indices. See discussion in [issue #37](https://github.com/osteslag/Changeset/issues/37) for more details.
+
 ## UIKit Integration
 
 The offset values can be used directly in the animation blocks of `beginUpdates`/`endUpdates` on `UITableView` and `performBatchUpdates` on `UICollectionView` in that `Changeset` follows the principles explained under [_Batch Insertion, Deletion, and Reloading of Rows and Sections_](https://developer.apple.com/library/ios/documentation/UserExperience/Conceptual/TableView_iPhone/ManageInsertDeleteRow/ManageInsertDeleteRow.html#//apple_ref/doc/uid/TP40007451-CH10-SW9) in Apple’s guide.

--- a/Sources/Changeset.Edit.swift
+++ b/Sources/Changeset.Edit.swift
@@ -13,7 +13,7 @@ public extension Changeset {
 		
 		- seealso: Discussions on GitHub: [#37](https://github.com/osteslag/Changeset/issues/37), [#39](https://github.com/osteslag/Changeset/pull/39#discussion_r129030599).
 		*/
-		public typealias Offset = C.IndexDistance
+		public typealias Offset = Int
 		
 		public typealias Element = C.Iterator.Element
 		

--- a/Sources/Changeset.Edit.swift
+++ b/Sources/Changeset.Edit.swift
@@ -7,7 +7,12 @@ public extension Changeset {
 	
 	public struct Edit {
 		
-		/// The type used to refer to elements in the collections.
+		/** The type used to refer to elements in the collections.
+		
+		Because not all collection indices are zero-based (e.g., a subsequence), an `Edit` uses *offsets* to refer to elements in the collection.
+		
+		- seealso: Discussions on GitHub: [#37](https://github.com/osteslag/Changeset/issues/37), [#39](https://github.com/osteslag/Changeset/pull/39#discussion_r129030599).
+		*/
 		public typealias Offset = Int
 		
 		/// The type used to refer to the element type of a collection.

--- a/Sources/Changeset.Edit.swift
+++ b/Sources/Changeset.Edit.swift
@@ -7,14 +7,10 @@ public extension Changeset {
 	
 	public struct Edit {
 		
-		/** The type used to refer to elements in the collections.
-		
-		Because not all collection indices are zero-based, let alone `Int`-based, an `Edit` uses *offsets* to elements in the collection.
-		
-		- seealso: Discussions on GitHub: [#37](https://github.com/osteslag/Changeset/issues/37), [#39](https://github.com/osteslag/Changeset/pull/39#discussion_r129030599).
-		*/
+		/// The type used to refer to elements in the collections.
 		public typealias Offset = Int
 		
+		/// The type used to refer to the element type of a collection.
 		public typealias Element = C.Iterator.Element
 		
 		/// Defines the type of an `Edit`.

--- a/Sources/Changeset.swift
+++ b/Sources/Changeset.swift
@@ -10,7 +10,7 @@ It detects additions, deletions, substitutions, and moves. Data is a `Collection
 
   - seealso: `Changeset.edits`.
 */
-public struct Changeset<C: Collection> where C.Iterator.Element: Equatable, C.IndexDistance == Int {
+public struct Changeset<C: Collection> where C.Iterator.Element: Equatable {
 	
 	/// Closure used to compare two elements.
 	public typealias Comparator = (C.Iterator.Element, C.Iterator.Element) -> Bool


### PR DESCRIPTION
Xcode has been bugging me about IndexDistance now always being an Int. This PR fixes that.

It leaves the Offset typealias intact, since it's still a nice thing to have explicit amongst other potential `Int`s.

Fixes #47 