### PR TITLE
Fix Xcode 12 issue about iOS 8 being unsupported.

### DIFF
--- a/Changeset.podspec
+++ b/Changeset.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |spec|
 	spec.source_files = 'Sources/*.swift'
 	spec.requires_arc = true
 	spec.swift_version = '5.0'
-	spec.ios.deployment_target = '8.0'
+	spec.ios.deployment_target = '9.0'
 	spec.tvos.deployment_target = '9.0'
 	spec.osx.deployment_target = '10.9'
 	spec.watchos.deployment_target = '2.0'

--- a/Package.swift
+++ b/Package.swift
@@ -5,13 +5,6 @@ import PackageDescription
 
 let package = Package(
 	name: "Changeset",
-	platforms: [
-		.macOS(.v10_10),
-		.iOS(.v8),
-		.tvOS(.v9),
-		.watchOS(.v2)
-		// Note: These might not be accurate
-	],
 	products: [
 		.library(
 			name: "Changeset",


### PR DESCRIPTION
Currently with Xcode 12 using Changeset produces warning:

```
The iOS Simulator deployment target 'IPHONEOS_DEPLOYMENT_TARGET' is set to 8.0, but the range of supported deployment target versions is 9.0 to 14.0.99.
```

This PR changes minimum iOS deployment target for CocoaPods to 9.0, and removed platforms from Package.swift.

Please note, that platforms inside Package.swift do not specify *supported platforms*, but rather *minimum versions of supported platforms*, which is only needed if package minimum deployment target is higher than SPM supported deployment targets.